### PR TITLE
change default quantum run_strategy to local(1 instance only)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -69,6 +69,7 @@ if config_env() == :prod do
   config :line_reminder, LineReminder.Scheduler,
     timezone: "Asia/Taipei",
     overlap: false,
+    run_strategy: Quantum.RunStrategy.Local,
     jobs: [
       {"0 6 * * *", {LineReminder.Messanger, :send, []}}
     ]


### PR DESCRIPTION
ChatGPT😈 says: 
> In the context of Quantum for Elixir's cron job scheduling, the "Local Node" run strategy refers to executing the cron jobs on the same Elixir node where the Quantum scheduler is running.
> 
> When using the "Local Node" strategy, Quantum runs the scheduled jobs directly on the same node without distributing the workload across multiple nodes or processes. This means that the jobs will be executed within the same Elixir runtime where the Quantum scheduler is running.
> 
> Using the "Local Node" strategy can be beneficial in certain scenarios. For example, if you have a relatively small number of cron jobs or if the jobs require access to local resources or state that is only available on the same Elixir node.
> 
> However, it's important to note that using the "Local Node" strategy can introduce limitations in terms of scalability and fault tolerance. If the node running the Quantum scheduler goes down or becomes unresponsive, the cron jobs will also be affected. Additionally, if you have a large number of cron jobs that require significant processing power, using a single node may not be sufficient to handle the workload.
> 
> In summary, the "Local Node" run strategy in Quantum for Elixir's cron job scheduling means that the jobs are executed on the same Elixir node where the Quantum scheduler is running, providing direct access to local resources but with potential scalability and fault tolerance limitations.

Let's take a try on this sloution.