### PR TITLE
turn off release_command

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,8 +7,8 @@ app = "bible-reminder"
 primary_region = "sin"
 kill_signal = "SIGTERM"
 
-[deploy]
-  release_command = "/app/bin/migrate"
+#[deploy]
+  # release_command = "/app/bin/migrate"
 
 [env]
   PHX_HOST = "bible-reminder.fly.dev"


### PR DESCRIPTION
When running deployment, it tried to run migration and stuck on there for 1 hour and 15 mins above.
I canceled the workflow from [Actions](https://github.com/denielchiang/line_reminder/actions/runs/5499657956).
And comment the running setting in the `fly.toml`