### PR TITLE
modify welcome message and receiver quiteria

### DIFF
--- a/lib/line_reminder/behaviours/sns/line.ex
+++ b/lib/line_reminder/behaviours/sns/line.ex
@@ -7,7 +7,6 @@ defmodule LineReminder.Sns.Line do
   @behaviour LineReminder.SnsBehaviour
 
   @api_header [{"Content-Type", "application/x-www-form-urlencoded"}]
-  @congrats_msg "\n您已訂閱[一般組]讀經進度小幫手\n🚀🚀🚀🚀🚀🚀"
   @congrats_sticker_package 11_537
   @congrats_sticker_id 52_002_734
 
@@ -28,14 +27,18 @@ defmodule LineReminder.Sns.Line do
     - {:error, reason} on failure.
   """
   @impl true
-  def send_congrats(token) do
+  def send_congrats(token, group) do
     %{
       stickerPackageId: @congrats_sticker_package,
       stickerId: @congrats_sticker_id,
-      message: @congrats_msg
+      message: choose_msg(group)
     }
     |> send_to_group(token)
   end
+
+  defp choose_msg("general"), do: "\n您已訂閱[一般組]讀經進度小幫手\n🚀🚀🚀🚀🚀🚀"
+  defp choose_msg("advanced"), do: "\n您已訂閱[速讀組]讀經進度小幫手\n🚀🚀🚀🚀🚀🚀"
+  defp choose_msg("companion"), do: "\n您已訂閱[陪讀組]讀經進度小幫手\n🚀🚀🚀🚀🚀🚀"
 
   @progress_sticker_package 11_537
   @progress_sticker_id 52_002_768

--- a/lib/line_reminder/behaviours/sns_behaviour.ex
+++ b/lib/line_reminder/behaviours/sns_behaviour.ex
@@ -1,7 +1,7 @@
 defmodule LineReminder.SnsBehaviour do
   @moduledoc false
 
-  @callback send_congrats(String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  @callback send_congrats(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
   @callback send_progress(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
   @callback send_to_group(map(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
 end

--- a/lib/line_reminder_web/controllers/subscribe_controller.ex
+++ b/lib/line_reminder_web/controllers/subscribe_controller.ex
@@ -58,7 +58,7 @@ defmodule LineReminderWeb.SubscribeController do
     end)
     |> then(fn
       {:ok, receiver} ->
-        Line.send_congrats(receiver.token)
+        Line.send_congrats(receiver.token, program)
 
       {:error, msg} ->
         Logger.error(msg)


### PR DESCRIPTION
### Fixed
- Welcome message content will be sent depends on which group that user subscribed.
- Changed the query quiteria for listing receivers. The very first time of subscriber will be queried in the next schedule task, no need to wait until the day after tomorrow.