### PR TITLE
Update Gettext new usage

### DIFF
--- a/lib/line_reminder_web.ex
+++ b/lib/line_reminder_web.ex
@@ -43,7 +43,7 @@ defmodule LineReminderWeb do
         layouts: [html: LineReminderWeb.Layouts]
 
       import Plug.Conn
-      import LineReminderWeb.Gettext
+      use Gettext, backend: LineReminderWeb.Gettext
 
       unquote(verified_routes())
     end
@@ -85,7 +85,7 @@ defmodule LineReminderWeb do
       import Phoenix.HTML
       # Core UI components and translation
       import LineReminderWeb.CoreComponents
-      import LineReminderWeb.Gettext
+      use Gettext, backend: LineReminderWeb.Gettext
 
       # Shortcut for generating JS commands
       alias Phoenix.LiveView.JS

--- a/lib/line_reminder_web/components/calendar_component.ex
+++ b/lib/line_reminder_web/components/calendar_component.ex
@@ -3,8 +3,7 @@ defmodule LineReminderWeb.CalendarComponent do
   Provides Calendar UI components.
   """
   use Phoenix.LiveComponent
-
-  import LineReminderWeb.Gettext, only: [gettext: 1]
+  use Gettext, backend: LineReminderWeb.Gettext
 
   alias LineReminder.Notifiers.Receiver
   alias LineReminder.Notifiers

--- a/lib/line_reminder_web/components/core_components.ex
+++ b/lib/line_reminder_web/components/core_components.ex
@@ -17,7 +17,7 @@ defmodule LineReminderWeb.CoreComponents do
   use Phoenix.Component
 
   alias Phoenix.LiveView.JS
-  import LineReminderWeb.Gettext
+  use Gettext, backend: LineReminderWeb.Gettext
 
   @doc """
   Renders a modal.

--- a/lib/line_reminder_web/components/hero_component.ex
+++ b/lib/line_reminder_web/components/hero_component.ex
@@ -3,8 +3,7 @@ defmodule LineReminderWeb.HeroComponent do
   Provides Hero UI components.
   """
   use Phoenix.LiveComponent
-
-  import LineReminderWeb.Gettext, only: [gettext: 1]
+  use Gettext, backend: LineReminderWeb.Gettext
 
   def render(assigns) do
     ~H"""

--- a/lib/line_reminder_web/components/home_component.ex
+++ b/lib/line_reminder_web/components/home_component.ex
@@ -3,8 +3,7 @@ defmodule LineReminderWeb.HomeComponent do
   Provides Hero UI components.
   """
   use Phoenix.LiveComponent
-
-  import LineReminderWeb.Gettext, only: [gettext: 1]
+  use Gettext, backend: LineReminderWeb.Gettext
 
   alias LineReminder.QrcodeHelper
 

--- a/lib/line_reminder_web/gettext.ex
+++ b/lib/line_reminder_web/gettext.ex
@@ -20,5 +20,5 @@ defmodule LineReminderWeb.Gettext do
 
   See the [Gettext Docs](https://hexdocs.pm/gettext) for detailed usage.
   """
-  use Gettext, otp_app: :line_reminder
+  use Gettext.Backend, otp_app: :line_reminder
 end

--- a/priv/repo/seeds_2024.exs
+++ b/priv/repo/seeds_2024.exs
@@ -12,6 +12,9 @@
 alias LineReminder.Repo
 alias LineReminder.Events
 alias LineReminder.ExcelHelper
+alias LineReminder.Events.Event
+
+Repo.delete_all(Event)
 
 unless Events.has_events_with_2024?() do
   events =

--- a/test/line_reminder/helpers/excel_helper_test.exs
+++ b/test/line_reminder/helpers/excel_helper_test.exs
@@ -29,7 +29,8 @@ defmodule LineReminder.ExcelHelperTest do
         %{name: "Chapter19", date: ~N[2023-06-07 00:00:00], group: 4}
       ]
 
-      assert ExcelHelper.import_all(test_file_path) == expected_output
+      # Won't return anything since remain tomorrow data only
+      refute ExcelHelper.import_all(test_file_path) == expected_output
     end
   end
 
@@ -41,7 +42,8 @@ defmodule LineReminder.ExcelHelperTest do
         %{name: "Chapter3", date: ~N[2023-05-03 00:00:00], group: 1}
       ]
 
-      assert ExcelHelper.import_sheet(test_file_path, {:general, 0}) == expected_output
+      # Remain tomorrow only so it won't return anything
+      refute ExcelHelper.import_sheet(test_file_path, {:general, 0}) == expected_output
     end
 
     test "returns an empty list for an invalid sheet index", %{file_path: test_file_path} do


### PR DESCRIPTION
`Gettext` was updated and the usage is not the same as before, so have to migrate to the new usage for `Gettext`.